### PR TITLE
Add stampie/stampie 1.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.4
     - 5.5
     - 5.6
     - 7.0
@@ -11,8 +10,6 @@ php:
 
 matrix:
     include:
-        - php: 5.3
-          dist: precise
         - php: 5.6
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
         - php: 7.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://secure.travis-ci.org/stof/StampieExtra.png)](http://travis-ci.org/stof/StampieExtra)
 
-StampieExtra provides an event-based extension point for [Stampie](https://github.com/henrikbjorn/Stampie).
+StampieExtra provides an event-based extension point for [Stampie](https://github.com/Stampie/Stampie).
 It uses the Symfony2 EventDispatcher component.
 
 ## Usage
@@ -13,11 +13,11 @@ in the sendign process.
 ```php
 <?php
 
-// include the Composr autoloading
+// include the Composer autoloading
 require 'vendor/autoload.php';
 
-$adapter = new Stampie\Adapter\Buzz(new Buzz\Browser());
-$innerMailer = new Stampie\Mailer\SendGrid($adapter, 'username:password');
+$httpClient = new Http\Adapter\Guzzle6\Client();
+$innerMailer = new Stampie\Mailer\SendGrid($httpClient, 'username:password');
 
 $dispatcher = new Symfony\Component\EventDispatcher\EventDispatcher();
 $mailer = new Stampie\Extra\Mailer($innerMailer, $dispatcher);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name" : "stof/stampie-extra",
-    "description" : "Event-based plugin for henrikbjorn/stampie",
+    "description" : "Event-based plugin for stampie/stampie",
     "homepage" : "https://github.com/stof/StampieExtra",
     "type" : "library",
     "license" : "MIT",
@@ -23,11 +23,12 @@
     "minimum-stability": "dev",
     "require" : {
         "php": ">=5.3.3",
-        "henrikbjorn/stampie": "~0.10",
+        "stampie/stampie": "^1.0",
         "symfony/event-dispatcher": "^2.3 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.1",
+        "php-http/mock-client": "^1.0",
         "psr/log": "^1.0",
         "symfony/phpunit-bridge": "^3.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "minimum-stability": "dev",
     "require" : {
-        "php": ">=5.3.3",
+        "php": ">=5.5",
         "stampie/stampie": "^1.0",
         "symfony/event-dispatcher": "^2.3 || ^3.0"
     },
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.3.x-dev"
+            "dev-master": "1.0.x-dev"
         }
     }
 }

--- a/src/Stampie/Extra/DecoratorMailer.php
+++ b/src/Stampie/Extra/DecoratorMailer.php
@@ -2,9 +2,9 @@
 
 namespace Stampie\Extra;
 
+use Http\Client\HttpClient;
 use Stampie\MailerInterface;
 use Stampie\MessageInterface;
-use Stampie\Adapter\AdapterInterface;
 
 /**
  * base MailerInterface decorator without extra logic.
@@ -31,22 +31,6 @@ class DecoratorMailer implements MailerInterface
     /**
      * {@inheritDoc}
      */
-    public function setAdapter(AdapterInterface $adapter)
-    {
-        $this->delegate->setAdapter($adapter);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getAdapter()
-    {
-        return $this->delegate->getAdapter();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function setServerToken($serverToken)
     {
         $this->delegate->setServerToken($serverToken);
@@ -58,5 +42,13 @@ class DecoratorMailer implements MailerInterface
     public function getServerToken()
     {
         return $this->delegate->getServerToken();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setHttpClient(HttpClient $adapter)
+    {
+        $this->delegate->setHttpClient($adapter);
     }
 }

--- a/tests/Stampie/Extra/Tests/MailerTest.php
+++ b/tests/Stampie/Extra/Tests/MailerTest.php
@@ -30,26 +30,15 @@ class MailerTest extends TestCase
         $this->mailer = new Mailer($this->delegate, $this->dispatcher);
     }
 
-    public function testSetAdapter()
+    public function testSetHttpClient()
     {
-        $adapter = $this->getMockBuilder('Stampie\Adapter\AdapterInterface')->getMock();
+        $httpClient = $this->getMockBuilder('Http\Client\HttpClient')->getMock();
 
         $this->delegate->expects($this->once())
-            ->method('setAdapter')
-            ->with($this->equalTo($adapter));
+            ->method('setHttpClient')
+            ->with($this->equalTo($httpClient));
 
-        $this->mailer->setAdapter($adapter);
-    }
-
-    public function testGetAdapter()
-    {
-        $adapter = $this->getMockBuilder('Stampie\Adapter\AdapterInterface')->getMock();
-
-        $this->delegate->expects($this->once())
-            ->method('getAdapter')
-            ->will($this->returnValue($adapter));
-
-        $this->assertSame($adapter, $this->mailer->getAdapter());
+        $this->mailer->setHttpClient($httpClient);
     }
 
     public function testSetServerToken()


### PR DESCRIPTION
This add support for `stampie/stampie` 1.0 which now use HTTPlug instead of adapters. 