### PR TITLE
Fix PHPUnit build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,18 @@ php:
     - 5.6
     - 7.0
     - 7.1
-    - hhvm
+    - 7.2
+    - nightly
 
 matrix:
     include:
         - php: 5.3
           dist: precise
-        - php: 5.3
-          dist: precise
+        - php: 5.6
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
         - php: 7.1
           env: DEPENDENCIES=dev SYMFONY_DEPRECATIONS_HELPER=weak
     allow_failures:
-        - php: hhvm
         - php: nightly
 
 sudo: false
@@ -28,7 +27,7 @@ cache:
         - $HOME/.composer/cache/files
 
 before_install:
-    - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+    - if [ "$DEPENDENCIES" = "dev" ]; then composer config minimum-stability dev; fi;
 
 install: composer update --prefer-dist $COMPOSER_FLAGS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
@@ -12,6 +11,9 @@ php:
 matrix:
     include:
         - php: 5.3
+          dist: precise
+        - php: 5.3
+          dist: precise
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
         - php: 7.1
           env: DEPENDENCIES=dev SYMFONY_DEPRECATIONS_HELPER=weak

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,7 @@ before_install:
 
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
-before_script: phpunit --version
-
-script: phpunit -v --coverage-clover=coverage.clover
+script: vendor/bin/phpunit -v --coverage-clover=coverage.clover
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
 
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
+before_script: phpunit --version
+
 script: phpunit -v --coverage-clover=coverage.clover
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symfony/event-dispatcher": "^2.3 || ^3.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.1",
         "psr/log": "^1.0",
         "symfony/phpunit-bridge": "^3.2"
     },

--- a/tests/Stampie/Extra/Tests/MailerTest.php
+++ b/tests/Stampie/Extra/Tests/MailerTest.php
@@ -2,10 +2,11 @@
 
 namespace Stampie\Extra\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Stampie\Extra\Mailer;
 use Stampie\Extra\StampieEvents;
 
-class MailerTest extends \PHPUnit_Framework_TestCase
+class MailerTest extends TestCase
 {
     /**
      * @var Mailer
@@ -24,14 +25,14 @@ class MailerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->delegate = $this->getMock('Stampie\MailerInterface');
-        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->delegate = $this->getMockBuilder('Stampie\MailerInterface')->getMock();
+        $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->mailer = new Mailer($this->delegate, $this->dispatcher);
     }
 
     public function testSetAdapter()
     {
-        $adapter = $this->getMock('Stampie\Adapter\AdapterInterface');
+        $adapter = $this->getMockBuilder('Stampie\Adapter\AdapterInterface')->getMock();
 
         $this->delegate->expects($this->once())
             ->method('setAdapter')
@@ -42,7 +43,7 @@ class MailerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAdapter()
     {
-        $adapter = $this->getMock('Stampie\Adapter\AdapterInterface');
+        $adapter = $this->getMockBuilder('Stampie\Adapter\AdapterInterface')->getMock();
 
         $this->delegate->expects($this->once())
             ->method('getAdapter')
@@ -75,7 +76,7 @@ class MailerTest extends \PHPUnit_Framework_TestCase
 
     public function testSend()
     {
-        $message = $this->getMock('Stampie\MessageInterface');
+        $message = $this->getMockBuilder('Stampie\MessageInterface')->getMock();
 
         $this->delegate->expects($this->once())
             ->method('send')


### PR DESCRIPTION
To make tests green again, I did the following changes:
- use `precise` build environment for PHP 5.3 as travis-ci default is now `trusty`.
- require `phpunit/phpunit` as dev-dependency to have proper PHPUnit with forward compatibility layer.
- use forward compatibility layer for PHPUnit 6 compatibility
- use `getMockBuilder()->getMock()` instead of deprecated `getMock()` calls.